### PR TITLE
fix: gate POST /api/gdoc behind admin key

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -14,6 +14,8 @@ declare global {
 		interface Platform {
 			env: {
 				ASSETS: { fetch: typeof fetch };
+				/** Secret shared with trusted callers to trigger a data refresh. */
+				ADMIN_KEY: string;
 			};
 		}
 	}

--- a/src/routes/api/gdoc/+server.ts
+++ b/src/routes/api/gdoc/+server.ts
@@ -19,7 +19,11 @@ export const GET: RequestHandler = async () => {
 	}
 };
 
-export const POST: RequestHandler = async (request) => {
+export const POST: RequestHandler = async ({ request, platform }) => {
+	const key = request.headers.get('x-admin-key');
+	if (!platform?.env?.ADMIN_KEY || key !== platform.env.ADMIN_KEY) {
+		return json({ error: 'unauthorized' }, { status: 401 });
+	}
 	try {
 		await updateData();
 		return json({ success: true });


### PR DESCRIPTION
Closes #3

The POST handler at `src/routes/api/gdoc/+server.ts:22` called `updateData()` with no authentication check. Any unauthenticated caller could trigger Google Sheets reads and overwrite `table.json`/`sheets.json` in R2.

**Impact:** quota/cost abuse (exhausted Sheets API quota, R2 write costs) and data clobbering (POST during mid-edit state overwrites published data with inconsistent snapshot).

**Fix:** gate behind `x-admin-key` header checked against `ADMIN_KEY` env var. Returns 401 if missing or mismatched.

Typecheck clean (pre-existing unrelated errors in `data.ts`/`image.ts` remain).