### PR TITLE
fix: fall back to manual segmentation when Intl.Segmenter is unavailable

### DIFF
--- a/src/lib/segment.ts
+++ b/src/lib/segment.ts
@@ -53,7 +53,7 @@ export function segment(text: string, language: string): Intl.SegmentData[] {
 	if (typeof Intl.Segmenter === 'undefined') {
 		let index = 0;
 		return text
-			.split(/([\s.,;:!?\-(){}[\]"']+)/u)
+			.split(/([\p{P}\p{S}\s]+)/u)
 			.filter(Boolean)
 			.map((segment) => {
 				const result = {

--- a/src/lib/segment.ts
+++ b/src/lib/segment.ts
@@ -46,11 +46,27 @@ export function segmentKatakana(text: string): Intl.SegmentData[] {
 }
 
 export function segment(text: string, language: string): Intl.SegmentData[] {
-	return language === 'ain'
-		? segmentAinu(text)
-		: language === 'ain-Kana'
-			? segmentKatakana(text)
-			: [...new Intl.Segmenter(language, { granularity: 'word' }).segment(text)];
+	if (language === 'ain') return segmentAinu(text);
+	if (language === 'ain-Kana') return segmentKatakana(text);
+	// Intl.Segmenter is unavailable in Firefox 115 ESR — fall back to a simple
+	// whitespace/punctuation split that produces the same Intl.SegmentData shape.
+	if (typeof Intl.Segmenter === 'undefined') {
+		let index = 0;
+		return text
+			.split(/([\s.,;:!?\-(){}[\]"']+)/u)
+			.filter(Boolean)
+			.map((segment) => {
+				const result = {
+					index,
+					input: text,
+					segment,
+					isWordLike: !isNonWordLike(segment)
+				} as Intl.SegmentData;
+				index += segment.length;
+				return result;
+			});
+	}
+	return [...new Intl.Segmenter(language, { granularity: 'word' }).segment(text)];
 }
 
 export function getRelativeHighlightIndicesInRange(


### PR DESCRIPTION
Fixes #1.

Firefox 115 ESR does not implement `Intl.Segmenter`, causing `Intl.Segmenter is not a constructor` which blanks the entire glossary page. Add a whitespace/punctuation split fallback that produces the same `Intl.SegmentData` shape so the site renders on all browsers.

Note: the `Error converting Latn ... to Kana` messages in the issue log are already caught gracefully in `script.svelte.ts` (returns the Latin fallback) — they are console noise, not crashes. The actual page-blanking crash was the missing `Intl.Segmenter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text segmentation for Ainu (`ain`) and Ainu Kana (`ain-Kana`) by using dedicated handling.
  * Added a runtime fallback for text segmentation when native `Intl.Segmenter` is unavailable.
  * Maintained accurate “word-like” classification in the segmented output across languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->